### PR TITLE
feat: display note path in search modal

### DIFF
--- a/components/portal/search-modal/search-item.tsx
+++ b/components/portal/search-modal/search-item.tsx
@@ -18,7 +18,6 @@ const SearchItem: FC<{
     search: { close },
   } = PortalState.useContainer()
   const { getPaths } = NoteTreeState.useContainer()
-  console.log(getPaths(note))
 
   const ref = useRef<HTMLLIElement>(null)
   useScrollView(ref, selected)


### PR DESCRIPTION

This PR adds the breadcrumbs from a note to the search results modal. It also fixes the almost invisible timestamp field. Again, feel free to merge this if you like it or close it if you don't 😃 

## Preview

![image](https://user-images.githubusercontent.com/2472626/139139886-82f6dcce-64db-4daf-b39b-c79405858205.png)
