### PR TITLE
feat: Improve import & export function [WIP]

### DIFF
--- a/libs/shared/tree.ts
+++ b/libs/shared/tree.ts
@@ -116,6 +116,25 @@ const flattenTree = (
   )
 }
 
+function findParentTreeItems(tree: TreeModel, pid?: string) {
+  const parents = [] as TreeItemModel[]
+
+  let tempNotePid: string | undefined = pid
+  while (tempNotePid && tempNotePid !== ROOT_ID) {
+    const curData: TreeItemModel = tree.items[tempNotePid]
+    if (curData?.data) {
+      tempNotePid = curData.data.pid
+      parents.push(curData)
+    } else {
+      break
+    }
+  }
+
+  console.log("\x1b[36mLog%s: %o\x1b[0m", ": findParentTreeItems -> tree", tree);
+  return parents
+}
+
+
 const TreeActions = {
   addItem,
   mutateItem,
@@ -124,6 +143,7 @@ const TreeActions = {
   restoreItem,
   deleteItem,
   flattenTree,
+  findParentTreeItems,
 }
 
 export default TreeActions

--- a/libs/shared/tree.ts
+++ b/libs/shared/tree.ts
@@ -130,7 +130,6 @@ function findParentTreeItems(tree: TreeModel, pid?: string) {
     }
   }
 
-  console.log("\x1b[36mLog%s: %o\x1b[0m", ": findParentTreeItems -> tree", tree);
   return parents
 }
 

--- a/libs/web/state/tree.ts
+++ b/libs/web/state/tree.ts
@@ -19,23 +19,6 @@ import { uiCache } from '../cache'
 
 const TREE_CACHE_KEY = 'tree'
 
-const findParentTreeItems = (tree: TreeModel, note: NoteModel) => {
-  const parents = [] as TreeItemModel[]
-
-  let tempNote = note
-  while (tempNote.pid && tempNote.pid !== ROOT_ID) {
-    const curData = tree.items[tempNote.pid]
-    if (curData?.data) {
-      tempNote = curData.data
-      parents.push(curData)
-    } else {
-      break
-    }
-  }
-
-  return parents
-}
-
 const useNoteTree = (initData: TreeModel = DEFAULT_TREE) => {
   const { mutate, loading, fetch: fetchTree } = useTreeAPI()
   const [tree, setTree] = useState<TreeModel>(initData)
@@ -163,7 +146,7 @@ const useNoteTree = (initData: TreeModel = DEFAULT_TREE) => {
 
   const getPaths = useCallback((note: NoteModel) => {
     const tree = treeRef.current
-    return findParentTreeItems(tree, note).map((listItem) => listItem.data!)
+    return TreeActions.findParentTreeItems(tree, note.pid).map((listItem) => listItem.data!)
   }, [])
 
   const setItemsExpandState = useCallback(
@@ -191,14 +174,14 @@ const useNoteTree = (initData: TreeModel = DEFAULT_TREE) => {
 
   const showItem = useCallback(
     (note: NoteModel) => {
-      const parents = findParentTreeItems(treeRef.current, note)
+      const parents = TreeActions.findParentTreeItems(treeRef.current, note.pid)
       setItemsExpandState(parents, true)
     },
     [setItemsExpandState]
   )
 
   const checkItemIsShown = useCallback((note: NoteModel) => {
-    const parents = findParentTreeItems(treeRef.current, note)
+    const parents = TreeActions.findParentTreeItems(treeRef.current, note.pid)
     return reduce(parents, (value, item) => value && !!item.isExpanded, true)
   }, [])
 

--- a/pages/api/export.ts
+++ b/pages/api/export.ts
@@ -2,6 +2,7 @@ import { useAuth } from 'libs/server/middlewares/auth'
 import { useStore } from 'libs/server/middlewares/store'
 import AdmZip from 'adm-zip'
 import emojiRegex from 'emoji-regex'
+import { map } from 'lodash'
 import { api } from 'libs/server/connect'
 import TreeActions, { ROOT_ID } from 'libs/shared/tree'
 import { getPathNoteById } from 'libs/server/note-path'
@@ -16,34 +17,50 @@ export default api()
     const pid = (req.query.pid as string) || ROOT_ID
     const zip = new AdmZip()
     const tree = await req.state.treeStore.get()
-    const items = TreeActions.flattenTree(tree, pid)
     const duplicate: Record<string, number> = {}
 
+    // fill tree with notes metadata
     await Promise.all(
-      items.map(async (item) => {
+      map(tree.items, async (item) => {
         const note = await req.state.store.getObjectAndMeta(
           getPathNoteById(item.id)
         )
-        const metaJson = metaToJson(note.meta)
+        item.data = metaToJson(note.meta) as any
+        item.data!.content = note.content
+        return item
+      })
+    )
 
-        if (metaJson.deleted === NOTE_DELETED.DELETED) {
+    // add all notes to zip file
+    const items = TreeActions.flattenTree(tree, pid)
+    await Promise.all(
+      items.map(async (item) => {
+        if (!item.data || item.data.deleted === NOTE_DELETED.DELETED) {
           return
         }
 
-        const title = ((metaJson.title as string) ?? 'Untitled')
+        const title = ((item.data.title as string) ?? 'Untitled')
           .replace(/\//, '')
           .replace(emojiRegex(), '')
           .trim()
 
-        // TODO: tree is not fully populated (data is missing from items), otherwise this should work
-        const parentPath = TreeActions.findParentTreeItems(tree, metaJson.pid)
+        const parentPath = TreeActions.findParentTreeItems(tree, item.data.pid)
+          .reverse()
           .map((item) => item.data?.title || 'Untitled')
           .join('/')
 
-        const path = `${parentPath}${parentPath ? '/' : ''}${title}`
+        const path = [
+          parentPath,
+          item.children.length > 0 ? title : undefined, // a note with children is nested inside the folder of it's own name
+          title,
+        ]
+          .filter(Boolean)
+          .join('/')
+
+        // duplicate filename has a limitation: subtrees from identically named notes will get merged together, but no files will be lost
         zip.addFile(
           `${path}${duplicate[path] ? ` (${duplicate[path]})` : ''}.md`,
-          toBuffer(note.content)
+          toBuffer(item.data.content)
         )
         duplicate[path] = (duplicate[path] || 0) + 1
       })

--- a/pages/api/import.ts
+++ b/pages/api/import.ts
@@ -47,7 +47,7 @@ export default api()
     const notes: NoteModel[] = []
 
     await Promise.all(
-      zipEntries.map(async (zipEntry) => {
+      zipEntries.map(async (zipEntry) => { // TODO: support zipEntry also being nested folder
         if (!MARKDOWN_EXT.includes(extname(zipEntry.name))) {
           return
         }


### PR DESCRIPTION
> Keep in mind that this is a work in progress branch. I might rewrite git history here once done. Just wanted to open it now so people know I'm working on these issues.

Planning on tackling the following issues:

- #85
- TODO: #114

My current solution has one limitation that I know of: the trees of 2 identically names quotes will be merged (but the files won't be lost):

![2021-11-11_23-49-11](https://user-images.githubusercontent.com/2472626/141381739-19a62f65-56a5-47fd-b67d-761ebc43e73a.png)

If we want to resolve this, a breaking change will need to be made to the archive format:

- Use the old note id inside the file/folder names (id could also be reused instead of generating a new one)
- Dump S3 data inside the zip archive instead (flat list of md files + tree.json, could also contain all images?)

However, I don't necessary think this is a good idea. The current export format keeps the files very human-readable, while both options worsen this. The second option also starts to look more like a "backup" instead of an export (backups should be made of the s3/minio service imo).
It must also be said that it is also quite unlikely a user will create notes with identical names in the same place on the tree.
