### PR TITLE
Adding support for AWS IAM role credentials

### DIFF
--- a/libs/server/store/index.ts
+++ b/libs/server/store/index.ts
@@ -3,8 +3,8 @@ import { StoreS3 } from './providers/s3'
 
 export function createStore() {
   return new StoreS3({
-    accessKey: getEnv('STORE_ACCESS_KEY', undefined, true),
-    secretKey: getEnv('STORE_SECRET_KEY', undefined, true),
+    accessKey: getEnv('STORE_ACCESS_KEY'),
+    secretKey: getEnv('STORE_SECRET_KEY'),
     endPoint: getEnv('STORE_END_POINT'),
     bucket: getEnv('STORE_BUCKET', 'notea'),
     region: getEnv('STORE_REGION', 'us-east-1'),

--- a/libs/server/store/providers/s3.ts
+++ b/libs/server/store/providers/s3.ts
@@ -40,11 +40,14 @@ export class StoreS3 extends StoreProvider {
       forcePathStyle: config.pathStyle,
       region: config.region,
       endpoint: config.endPoint,
-      credentials: {
+      credentials: ((config.accessKey && config.secretKey) ? {
         accessKeyId: config.accessKey,
         secretAccessKey: config.secretKey,
-      },
+      }: undefined),
     })
+    if (!config.accessKey || !config.secretKey) {
+      console.log('[Notea] Environment variables STORE_ACCESS_KEY or STORE_SECRET_KEY is missing. Trying to use IAM role credentials instead ...')
+    }
     this.config = config
   }
 


### PR DESCRIPTION
Besides using IAM user credentials, AWS automatically injects credentials into most of their services (EC2, Fargate, Lambda, ...). The AWS SDK makes use of these credentials out-of-the-box. However, that mechanism does not work when setting the values manually, as it was the case inside the S3 provider so far.

Therefore, I made the environment variables `STORE_ACCESS_KEY` and `STORE_SECRET_KEY` optional. When the S3 client gets created without specific credentials, it will automatically try to access the IAM role credentials when running on an AWS platform like EC2 or Fargate.

By the way, this feature has been requested before. See https://github.com/QingWei-Li/notea/issues/95 for details.

Many thanks to @QingWei-Li for maintaining this amazing project. It is a great example for a slick web application built on S3.
