### PR TITLE
Improved configuration

### DIFF
--- a/config/compatibility.yml
+++ b/config/compatibility.yml
@@ -26,5 +26,10 @@ store:
     # proxyAttachments is the same as DIRECT_RESPONSE_ATTACHMENT; defaults to false
     proxyAttachments: true
 
+# Server configuration
+server:
+    # useSecureConfig is the same as COOKIE_SECURE; if in production (which is for end-users), it will be true, else it'll be false
+    useSecureConfig: true
+
 # baseUrl is the same as BASE_URL; not required
 baseUrl: https://example.com

--- a/config/compatibility.yml
+++ b/config/compatibility.yml
@@ -30,6 +30,5 @@ store:
 server:
     # useSecureConfig is the same as COOKIE_SECURE; if in production (which is for end-users), it will be true, else it'll be false
     useSecureConfig: true
-
-# baseUrl is the same as BASE_URL; not required
-baseUrl: https://example.com
+    # baseUrl is the same as BASE_URL; not required
+    baseUrl: https://example.com

--- a/config/compatibility.yml
+++ b/config/compatibility.yml
@@ -22,6 +22,9 @@ store:
     # secretKey is the same as STORE_SECRET_KEY; must be specified if env doesn't
     secretKey: YOUR_SECRET_KEY
     # forcePathStyle is the same as STORE_FORCE_PATH_STYLE; defaults to false
+    forcePathStyle: true
+    # proxyAttachments is the same as DIRECT_RESPONSE_ATTACHMENT; defaults to false
+    proxyAttachments: true
 
 # baseUrl is the same as BASE_URL; not required
 baseUrl: https://example.com

--- a/libs/server/config.ts
+++ b/libs/server/config.ts
@@ -33,14 +33,13 @@ export type StoreConfiguration = S3StoreConfiguration;
 
 export interface ServerConfiguration {
     useSecureCookies: boolean;
-    // TODO: Move baseUrl to here
+    baseUrl?: string;
 }
 
 export interface Configuration {
     auth: AuthConfiguration;
     store: StoreConfiguration;
     server: ServerConfiguration;
-    baseUrl?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -144,13 +143,13 @@ export function loadConfig() {
     }
     {
         server.useSecureCookies = env.parseBool(env.getEnvRaw('COOKIE_SECURE', false), process.env.NODE_ENV === 'production');
+        server.baseUrl = env.getEnvRaw('BASE_URL', false) ?? baseConfig.server.baseUrl;
     }
 
     loaded = {
         auth,
         store,
-        server,
-        baseUrl: env.getEnvRaw('BASE_URL', false) ?? baseConfig.baseUrl,
+        server
     };
 }
 

--- a/libs/server/config.ts
+++ b/libs/server/config.ts
@@ -31,9 +31,15 @@ export interface S3StoreConfiguration {
 
 export type StoreConfiguration = S3StoreConfiguration;
 
+export interface ServerConfiguration {
+    useSecureCookies: boolean;
+    // TODO: Move baseUrl to here
+}
+
 export interface Configuration {
     auth: AuthConfiguration;
     store: StoreConfiguration;
+    server: ServerConfiguration;
     baseUrl?: string;
 }
 
@@ -130,9 +136,20 @@ export function loadConfig() {
         store.proxyAttachments = env.parseBool(env.getEnvRaw('DIRECT_RESPONSE_ATTACHMENT', false), store.proxyAttachments ?? false);
     }
 
+    let server: ServerConfiguration;
+    if (!baseConfig.server) {
+        server = {} as ServerConfiguration;
+    } else {
+        server = baseConfig.server;
+    }
+    {
+        server.useSecureCookies = env.parseBool(env.getEnvRaw('COOKIE_SECURE', false), process.env.NODE_ENV === 'production');
+    }
+
     loaded = {
         auth,
         store,
+        server,
         baseUrl: env.getEnvRaw('BASE_URL', false) ?? baseConfig.baseUrl,
     };
 }

--- a/libs/server/config.ts
+++ b/libs/server/config.ts
@@ -26,6 +26,7 @@ export interface S3StoreConfiguration {
     region: string;
     forcePathStyle: boolean;
     prefix: string;
+    proxyAttachments: boolean;
 }
 
 export type StoreConfiguration = S3StoreConfiguration;
@@ -126,6 +127,7 @@ export function loadConfig() {
             'STORE_PREFIX',
             false,
         ) ?? store.prefix ?? '';
+        store.proxyAttachments = env.parseBool(env.getEnvRaw('DIRECT_RESPONSE_ATTACHMENT', false), store.proxyAttachments ?? false);
     }
 
     loaded = {

--- a/libs/server/middlewares/csrf.ts
+++ b/libs/server/middlewares/csrf.ts
@@ -1,13 +1,13 @@
 import Tokens from 'csrf';
 import { CSRF_HEADER_KEY } from 'libs/shared/const';
-import { getEnv } from 'libs/shared/env';
 import md5 from 'md5';
 import { ApiNext, ApiRequest, ApiResponse, SSRMiddleware } from '../connect';
+import { BasicAuthConfiguration, config } from 'libs/server/config';
 
 const tokens = new Tokens();
 
 // generate CSRF secret
-const csrfSecret = md5('CSRF' + getEnv('PASSWORD'));
+const csrfSecret = md5('CSRF' + (config().auth as BasicAuthConfiguration).password);
 
 export const getCsrfToken = () => tokens.create(csrfSecret);
 

--- a/libs/server/middlewares/note.ts
+++ b/libs/server/middlewares/note.ts
@@ -32,7 +32,7 @@ export const applyNote: (id: string) => SSRMiddleware =
         req.props = {
             ...req.props,
             ...props,
-            baseURL: config()?.baseUrl || 'http://' + req.headers.host,
+            baseURL: config().server.baseUrl ?? 'http://' + req.headers.host,
         };
 
         next();

--- a/libs/server/middlewares/session.ts
+++ b/libs/server/middlewares/session.ts
@@ -1,16 +1,13 @@
 import { ironSession } from 'next-iron-session';
 import md5 from 'md5';
-import { getEnv } from 'libs/shared/env';
+import { BasicAuthConfiguration, config } from 'libs/server/config';
 
 const sessionOptions = {
     cookieName: 'notea-auth',
-    password: md5('notea' + getEnv('PASSWORD')),
+    password: md5('notea' + (config().auth as BasicAuthConfiguration).password), // NOTE(tecc): in the future, if this field becomes null, it will be an issue
     // if your localhost is served on http:// then disable the secure flag
     cookieOptions: {
-        secure: getEnv<boolean>(
-            'COOKIE_SECURE',
-            process.env.NODE_ENV === 'production'
-        ),
+        secure: config().server.useSecureCookies,
     },
 };
 

--- a/libs/shared/env.ts
+++ b/libs/shared/env.ts
@@ -14,6 +14,9 @@ type AllowedEnvs =
     | 'STORE_PREFIX'
     | 'CONFIG_FILE';
 
+/**
+ * @deprecated This function should not be used. Prefer the `config()` system.
+ */
 export function getEnv<T>(
     env: AllowedEnvs,
     defaultValue?: any,

--- a/libs/shared/env.ts
+++ b/libs/shared/env.ts
@@ -44,3 +44,45 @@ export function getEnv<T>(
 
     return result as unknown as T;
 }
+
+export function getEnvRaw(env: AllowedEnvs, required: true): string;
+export function getEnvRaw(env: AllowedEnvs, required?: false): string | undefined;
+export function getEnvRaw(env: AllowedEnvs, required?: boolean): string | undefined;
+export function getEnvRaw(env: AllowedEnvs, required: boolean = false): string | undefined {
+    const value = process.env[env];
+
+    if (value == null) {
+        if (required) {
+            throw new Error(`[Notea] ${env} is undefined`);
+        } else {
+            return undefined;
+        }
+    }
+
+    return String(value).toLocaleLowerCase();
+}
+
+export function parseBool(str: string, invalid?: boolean): boolean;
+export function parseBool(str: null | undefined): undefined;
+export function parseBool(str: string | null | undefined, invalid: boolean): boolean;
+export function parseBool(str: string | null | undefined, invalid?: boolean): boolean | undefined;
+export function parseBool(str: string | null | undefined, invalid?: boolean): boolean | undefined {
+    if (str == null) {
+        return invalid ?? undefined;
+    }
+    switch (str.toLowerCase()) {
+        case "true":
+        case "1":
+        case "yes":
+        case "on":
+            return true;
+        case "false":
+        case "0":
+        case "no":
+        case "off":
+            return false;
+        default:
+            if (invalid == null) throw new Error("Invalid boolean: " + str);
+            else return invalid;
+    }
+}


### PR DESCRIPTION
This change is mostly internal but does entail two user-facing change;
- Created a new configuration section for file-based configurations: `server`.
- Added `server.useSecureCookies`, which is the equivalent of `COOKIE_SECURE`.
- For file configurations, `baseUrl` has been moved to `server.baseUrl`. See config/compatibility.yml

Internal changes:
- Replaced last direct usages of `getEnv`, and marked the function as deprecated. 
- Create new system for using environment variables:
  - `getEnvRaw` is used to access the variables; it only gives you a string, and never anything else.
  - `parseBool` parses booleans from strings. `true`, `1`, `yes`, and `on` are treated as `true` whilst `false`, `0`, `no`, and `off` are treated as `false`.
