### PR TITLE
change: Reworded footer in shared documents, updated link

### DIFF
--- a/components/container/post-container.tsx
+++ b/components/container/post-container.tsx
@@ -47,9 +47,9 @@ export const PostContainer: FC<{
                         />
                     ) : null}
                     <footer className="pb-10 text-gray-300 text-center my-20 text-sm">
-                        Built with{' '}
+                        Written with{' '}
                         <a
-                            href="https://cinwell.com/notea/"
+                            href="https://github.com/notea-org/notea"
                             target="_blank"
                             rel="noreferrer"
                         >


### PR DESCRIPTION
Previously, the footer said "Built with", which makes it seem too technical. This just changes it to "Written with", which is a more accurate portrayal. Fixes #154.
I also updated the link to point to https://github.com/notea-org/notea, which is preferred to the previous link (https://cinwell.com/notea) if a website for Notea is necessary.