### PR TITLE
Width and padding improvements for the editor

### DIFF
--- a/components/editor/main-editor.tsx
+++ b/components/editor/main-editor.tsx
@@ -5,6 +5,7 @@ import EditorState from 'libs/web/state/editor';
 import UIState from 'libs/web/state/ui';
 import { FC } from 'react';
 import { NoteModel } from 'libs/shared/note';
+import { EDITOR_SIZE } from 'libs/shared/meta';
 
 const MainEditor: FC<
     EditorProps & {
@@ -16,10 +17,18 @@ const MainEditor: FC<
     const {
         settings: { settings },
     } = UIState.useContainer();
-    const editorWidthClass =
-        (note?.editorsize ?? settings.editorsize) > 0
-            ? 'max-w-4xl'
-            : 'max-w-prose';
+    let editorWidthClass: string;
+    switch (note?.editorsize ?? settings.editorsize) {
+        case EDITOR_SIZE.SMALL:
+            editorWidthClass = 'max-w-prose';
+            break;
+        case EDITOR_SIZE.LARGE:
+            editorWidthClass = 'max-w-4xl';
+            break;
+        case EDITOR_SIZE.AS_WIDE_AS_POSSIBLE:
+            editorWidthClass = 'max-w-full mx-20';
+            break;
+    }
     const articleClassName =
         className || `pt-40 px-6 m-auto h-full ${editorWidthClass}`;
 

--- a/components/editor/main-editor.tsx
+++ b/components/editor/main-editor.tsx
@@ -31,7 +31,7 @@ const MainEditor: FC<
             break;
     }
     const articleClassName =
-        className || `pt-40 px-6 m-auto h-full ${editorWidthClass}`;
+        className || `pt-16 md:pt-40 px-6 m-auto h-full ${editorWidthClass}`;
 
     return (
         <EditorState.Provider initialState={note}>

--- a/components/editor/main-editor.tsx
+++ b/components/editor/main-editor.tsx
@@ -26,7 +26,8 @@ const MainEditor: FC<
             editorWidthClass = 'max-w-4xl';
             break;
         case EDITOR_SIZE.AS_WIDE_AS_POSSIBLE:
-            editorWidthClass = 'max-w-full mx-20';
+            // until we reach md size, just do LARGE to have consistency
+            editorWidthClass = 'max-w-4xl md:max-w-full md:mx-20';
             break;
     }
     const articleClassName =

--- a/components/icon-button.tsx
+++ b/components/icon-button.tsx
@@ -42,6 +42,7 @@ export const ICONS = {
     Puzzle: PuzzleIcon,
     ChevronDoubleUp: ChevronDoubleUpIcon,
     Refresh: RefreshIcon,
+    WidthSize: (props: any) => <SelectorIcon style={{ transform: 'rotate(90deg)' }} {...props}/>
 };
 
 const IconButton = forwardRef<

--- a/components/layout/layout-main.tsx
+++ b/components/layout/layout-main.tsx
@@ -17,6 +17,7 @@ import { NoteModel } from 'libs/shared/note';
 import PreviewModal from 'components/portal/preview-modal';
 import LinkToolbar from 'components/portal/link-toolbar/link-toolbar';
 import { ReactNodeLike } from 'prop-types';
+import EditorWidthSelect from 'components/portal/editor-width-select';
 
 const MainWrapper: FC<{ children: ReactNodeLike }> = ({ children }) => {
     const {
@@ -108,6 +109,7 @@ const LayoutMain: FC<{
                 <PreviewModal />
                 <LinkToolbar />
                 <SidebarMenu />
+                <EditorWidthSelect/>
             </NoteState.Provider>
         </NoteTreeState.Provider>
     );

--- a/components/note-nav.tsx
+++ b/components/note-nav.tsx
@@ -41,7 +41,7 @@ const NoteNav = () => {
     const { ua } = UIState.useContainer();
     const { getPaths, showItem, checkItemIsShown } =
         NoteTreeState.useContainer();
-    const { share, menu } = PortalState.useContainer();
+    const { share, menu, editorWidthSelect } = PortalState.useContainer();
 
     const handleClickShare = useCallback(
         (event: MouseEvent) => {
@@ -56,9 +56,18 @@ const NoteNav = () => {
         (event: MouseEvent) => {
             menu.setData(note);
             menu.setAnchor(event.target as Element);
+            // debugger;
             menu.open();
         },
         [note, menu]
+    );
+    const handleClickEditorWidth = useCallback(
+        (event: MouseEvent) => {
+            editorWidthSelect.setData(note);
+            editorWidthSelect.setAnchor(event.target as Element);
+            editorWidthSelect.open();
+        },
+        [note, editorWidthSelect]
     );
 
     const handleClickOpenInTree = useCallback(() => {
@@ -152,6 +161,14 @@ const NoteNav = () => {
                     })}
                     icon="Share"
                 />
+            </HotkeyTooltip>
+            <HotkeyTooltip text={t('Editor width')}>
+                <IconButton
+                    icon="WidthSize"
+                    className="mr-2"
+                    onClick={handleClickEditorWidth}
+                >
+                </IconButton>
             </HotkeyTooltip>
             <HotkeyTooltip text={t('Settings')}>
                 <IconButton

--- a/components/portal/editor-width-select.tsx
+++ b/components/portal/editor-width-select.tsx
@@ -4,6 +4,7 @@ import PortalState from 'libs/web/state/portal';
 import { Menu, MenuItem } from '@material-ui/core';
 import { EDITOR_SIZE } from 'libs/shared/meta';
 import NoteState from 'libs/web/state/note';
+import UIState from 'libs/web/state/ui';
 
 interface EditorWidthSelectItem {
     text: string;
@@ -15,6 +16,9 @@ const EditorWidthSelect: FC = () => {
     const {
         editorWidthSelect: { close, anchor, data, visible },
     } = PortalState.useContainer();
+    const {
+        settings: { settings },
+    } = UIState.useContainer();
     const { mutateNote } = NoteState.useContainer();
 
     const items: Array<EditorWidthSelectItem> = [
@@ -42,6 +46,8 @@ const EditorWidthSelect: FC = () => {
         }
     };
 
+    const editorWidth = data?.editorsize ?? settings.editorsize;
+
     return (
         <Menu
             anchorEl={anchor}
@@ -53,7 +59,9 @@ const EditorWidthSelect: FC = () => {
         >
             {items.map((item) =>
                 <MenuItem key={item.value} onClick={() => setTo(item.value)}>
-                    <span className="text-xs">{item.text}</span>
+                    <span className={`text-xs ${editorWidth == item.value ? 'font-bold' : ''}`}>
+                        {item.text}
+                    </span>
                 </MenuItem>
             )}
         </Menu>

--- a/components/portal/editor-width-select.tsx
+++ b/components/portal/editor-width-select.tsx
@@ -1,0 +1,63 @@
+import { FC } from 'react';
+import useI18n from 'libs/web/hooks/use-i18n';
+import PortalState from 'libs/web/state/portal';
+import { Menu, MenuItem } from '@material-ui/core';
+import { EDITOR_SIZE } from 'libs/shared/meta';
+import NoteState from 'libs/web/state/note';
+
+interface EditorWidthSelectItem {
+    text: string;
+    value: EDITOR_SIZE;
+}
+
+const EditorWidthSelect: FC = () => {
+    const { t } = useI18n();
+    const {
+        editorWidthSelect: { close, anchor, data, visible },
+    } = PortalState.useContainer();
+    const { mutateNote } = NoteState.useContainer();
+
+    const items: Array<EditorWidthSelectItem> = [
+        {
+            text: t("Small (default)"),
+            value: EDITOR_SIZE.SMALL,
+        },
+        {
+            text: t("Large"),
+            value: EDITOR_SIZE.LARGE
+        },
+        {
+            text: t("As wide as possible"),
+            value: EDITOR_SIZE.AS_WIDE_AS_POSSIBLE
+        }
+    ];
+
+    const setTo = (width: EDITOR_SIZE) => {
+        close();
+        if (data?.id) {
+            mutateNote(data.id, {
+                editorsize: width
+            })
+                .catch((v) => console.error("Error whilst switching editor size", v));
+        }
+    };
+
+    return (
+        <Menu
+            anchorEl={anchor}
+            open={visible}
+            onClose={close}
+            classes={{
+                paper: 'bg-gray-200 text-gray-800',
+            }}
+        >
+            {items.map((item) =>
+                <MenuItem key={item.value} onClick={() => setTo(item.value)}>
+                    <span className="text-xs">{item.text}</span>
+                </MenuItem>
+            )}
+        </Menu>
+    );
+};
+
+export default EditorWidthSelect;

--- a/components/portal/sidebar-menu/sidebar-menu-item.tsx
+++ b/components/portal/sidebar-menu/sidebar-menu-item.tsx
@@ -11,7 +11,7 @@ export enum MENU_HANDLER_NAME {
     COPY_LINK,
     ADD_TO_FAVORITES,
     REMOVE_FROM_FAVORITES,
-    TOGGLE_WIDTH,
+    SWITCH_EDITOR_WIDTH,
 }
 
 export interface Item {
@@ -74,7 +74,7 @@ export const SidebarMenuItem = forwardRef<HTMLLIElement, ItemProps>(
             }
         }, [close, data, mutateNote]);
 
-        const toggleWidth = useCallback(() => {
+        const switchEditorWidth = useCallback(() => {
             close();
             if (data?.id) {
                 const resolvedNoteWidth =
@@ -84,7 +84,7 @@ export const SidebarMenuItem = forwardRef<HTMLLIElement, ItemProps>(
                 mutateNote(data.id, {
                     editorsize: (resolvedNoteWidth + 1) % editorSizesCount,
                 })
-                    .catch((v) => console.error('Error whilst mutating note: %O', v));
+                    .catch((v) => console.error('Error whilst mutating note (editor width): %O', v));
             }
         }, [close, data, mutateNote, settings.editorsize]);
 
@@ -94,9 +94,9 @@ export const SidebarMenuItem = forwardRef<HTMLLIElement, ItemProps>(
                 [MENU_HANDLER_NAME.COPY_LINK]: doCopyLink,
                 [MENU_HANDLER_NAME.ADD_TO_FAVORITES]: doPinned,
                 [MENU_HANDLER_NAME.REMOVE_FROM_FAVORITES]: doUnpinned,
-                [MENU_HANDLER_NAME.TOGGLE_WIDTH]: toggleWidth,
+                [MENU_HANDLER_NAME.SWITCH_EDITOR_WIDTH]: switchEditorWidth,
             }),
-            [doCopyLink, doPinned, doRemoveNote, doUnpinned, toggleWidth]
+            [doCopyLink, doPinned, doRemoveNote, doUnpinned, switchEditorWidth]
         );
 
         return (

--- a/components/portal/sidebar-menu/sidebar-menu.tsx
+++ b/components/portal/sidebar-menu/sidebar-menu.tsx
@@ -47,10 +47,10 @@ const SidebarMenu: FC = () => {
                 },
             },
             {
-                text: t('Toggle width'),
+                text: t('Toggle width'), // TODO(i18n): Change this to 'Switch width'
                 // TODO: or SwitchHorizontal?
                 icon: <SelectorIcon style={{ transform: 'rotate(90deg)' }} />,
-                handler: MENU_HANDLER_NAME.TOGGLE_WIDTH,
+                handler: MENU_HANDLER_NAME.SWITCH_EDITOR_WIDTH,
             },
         ],
         [t]

--- a/components/portal/sidebar-menu/sidebar-menu.tsx
+++ b/components/portal/sidebar-menu/sidebar-menu.tsx
@@ -46,12 +46,12 @@ const SidebarMenu: FC = () => {
                     return item?.pinned === NOTE_PINNED.PINNED;
                 },
             },
-            {
-                text: t('Toggle width'), // TODO(i18n): Change this to 'Switch width'
-                // TODO: or SwitchHorizontal?
+            // Replaced by dedicated window
+            /*{
+                text: t('Toggle width'),
                 icon: <SelectorIcon style={{ transform: 'rotate(90deg)' }} />,
                 handler: MENU_HANDLER_NAME.SWITCH_EDITOR_WIDTH,
-            },
+            },*/
         ],
         [t]
     );

--- a/components/portal/sidebar-menu/sidebar-menu.tsx
+++ b/components/portal/sidebar-menu/sidebar-menu.tsx
@@ -2,7 +2,6 @@ import { Menu } from '@material-ui/core';
 import { FC, useMemo } from 'react';
 import {
     ClipboardCopyIcon,
-    SelectorIcon,
     StarIcon,
     TrashIcon,
 } from '@heroicons/react/outline';

--- a/components/settings/editor-width.tsx
+++ b/components/settings/editor-width.tsx
@@ -31,7 +31,12 @@ export const EditorWidth: FC = () => {
             <MenuItem value={EDITOR_SIZE.SMALL}>
                 {t('Small (default)')}
             </MenuItem>
-            <MenuItem value={EDITOR_SIZE.LARGE}>{t('Large')}</MenuItem>
+            <MenuItem value={EDITOR_SIZE.LARGE}>
+                {t('Large')}
+            </MenuItem>
+            <MenuItem value={EDITOR_SIZE.AS_WIDE_AS_POSSIBLE}>
+                {t('As wide as possible')}
+            </MenuItem>
         </TextField>
     );
 };

--- a/libs/shared/meta.ts
+++ b/libs/shared/meta.ts
@@ -16,6 +16,7 @@ export enum NOTE_PINNED {
 export enum EDITOR_SIZE {
     SMALL,
     LARGE,
+    AS_WIDE_AS_POSSIBLE = 2
 }
 
 export const PAGE_META_KEY = <const>[

--- a/libs/web/state/portal.ts
+++ b/libs/web/state/portal.ts
@@ -44,6 +44,7 @@ const useModal = () => {
             href: string;
             view?: RichMarkdownEditor['view'];
         }>(),
+        editorWidthSelect: useAnchorInstance<NoteModel>()
     };
 };
 


### PR DESCRIPTION
Adds a bunch of editor improvements mainly relating to the use of screen space.

This PR:
- Adds an "as wide as possible" width which uses as much screen space as reasonably possible whilst still looking nice. Fixes #167.
- Moves editor width settings to its own button, aptly titled "Editor width". It replaces toggling between widths with setting specific widths (along with highlighting which one is active for the note).
- Improves sizing on smaller screens by using previously unused screen space dedicated to padding.

See #167 for more information and screenshots.